### PR TITLE
Write _bg.wasm file to the same dir the .wasm file was located in

### DIFF
--- a/loader/index.js
+++ b/loader/index.js
@@ -12,7 +12,7 @@ async function run(cx, source) {
   const ret = await wasm_interface_types.compile(name, source, true);
   // TODO: should figure out how to not need to write to the actual filesystem
   // here.
-  await writeFileAsync(name + '_bg.wasm', ret.wasm());
+  await writeFileAsync(path.resolve(path.dirname(cx.resourcePath), name + '_bg.wasm'), ret.wasm());
   return ret.js();
 }
 


### PR DESCRIPTION
Otherwise the `_bg` file isn't found if the `.wasm` file is anywhere but in the main directory of the project.